### PR TITLE
Speed up research pipeline: parallel extraction/search, session reuse, bounded waste

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ result = engine.run_sync(
     )
 )
 print(result.report_markdown)
+engine.close()  # release the shared HTTP session
 ```
 
 ## Development

--- a/shandu/agents/citation_agent.py
+++ b/shandu/agents/citation_agent.py
@@ -36,7 +36,7 @@ class CitationAgent:
             return []
 
         evidence_json = json.dumps(
-            [item.model_dump(mode="json") for item in evidence], ensure_ascii=False
+            [self._project(item) for item in evidence], ensure_ascii=False
         )
         worker = Worker(
             name="CitationSubagent",
@@ -57,6 +57,17 @@ class CitationAgent:
             pass
 
         return self._fallback(evidence)
+
+    @staticmethod
+    def _project(item: EvidenceRecord) -> dict[str, str]:
+        return {
+            "evidence_id": item.evidence_id,
+            "requested_url": item.requested_url,
+            "final_url": item.final_url or "",
+            "title": item.title,
+            "domain": item.domain or "",
+            "snippet": (item.snippet or "")[:280],
+        }
 
     def _normalize(
         self,

--- a/shandu/agents/search_subagent.py
+++ b/shandu/agents/search_subagent.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+import asyncio
+from collections.abc import Awaitable, Callable, Sequence
 from typing import Any
 from urllib.parse import urlparse, urlsplit, urlunsplit
 
@@ -9,7 +10,12 @@ from blackgeorge.utils import new_id
 from pydantic import BaseModel, Field
 
 from ..contracts import EvidenceRecord, ResearchRequest, SubagentTask
-from ..interfaces import RuntimeExecutionLike, ScrapeServiceLike, SearchServiceLike
+from ..interfaces import (
+    RuntimeExecutionLike,
+    ScrapedPageLike,
+    ScrapeServiceLike,
+    SearchServiceLike,
+)
 from ..prompts import extractor_instructions, extractor_job
 
 SearchTraceCallback = Callable[[str, dict[str, Any]], Awaitable[None] | None]
@@ -40,10 +46,9 @@ class SearchSubagent:
         progress_callback: SearchTraceCallback | None = None,
     ) -> list[EvidenceRecord]:
         del run_scope
-        all_hits: list[dict[str, str]] = []
-        seen: set[str] = set()
+        queries = task.search_queries or [task.focus]
 
-        for query in task.search_queries or [task.focus]:
+        async def run_query(query: str) -> Sequence[Any]:
             await self._emit_trace(
                 progress_callback,
                 "query_started",
@@ -65,6 +70,13 @@ class SearchSubagent:
                     "urls": [hit.url for hit in hits[:8]],
                 },
             )
+            return hits
+
+        query_hits = await asyncio.gather(*(run_query(query) for query in queries))
+
+        all_hits: list[dict[str, str]] = []
+        seen: set[str] = set()
+        for hits in query_hits:
             for hit in hits:
                 if hit.url in seen:
                     continue
@@ -110,29 +122,11 @@ class SearchSubagent:
             if canonical_hit_url:
                 hits_by_url.setdefault(canonical_hit_url, entry)
 
-        evidence: list[EvidenceRecord] = []
-        for page in pages:
+        async def process_page(page: ScrapedPageLike) -> EvidenceRecord:
             if page.fetch_error is not None:
                 hit_payload = hits_by_url.get(page.requested_url)
                 snippet = str(hit_payload.get("snippet", "") if hit_payload else "").strip()
                 title = str(hit_payload.get("title", "") if hit_payload else page.title).strip() or page.url
-                extracted_text = snippet or title
-                evidence.append(
-                    EvidenceRecord(
-                        evidence_id=new_id(),
-                        task_id=task.task_id,
-                        query=task.focus,
-                        requested_url=page.requested_url,
-                        domain=page.domain,
-                        title=title,
-                        snippet=snippet or title,
-                        extracted_text=extracted_text,
-                        confidence=0.33,
-                        source_type="search_snippet",
-                        extraction_method="search_snippet_fallback",
-                        fetch_error=page.fetch_error,
-                    )
-                )
                 await self._emit_trace(
                     progress_callback,
                     "fallback_evidence",
@@ -144,7 +138,20 @@ class SearchSubagent:
                         "fetch_error": page.fetch_error,
                     },
                 )
-                continue
+                return EvidenceRecord(
+                    evidence_id=new_id(),
+                    task_id=task.task_id,
+                    query=task.focus,
+                    requested_url=page.requested_url,
+                    domain=page.domain,
+                    title=title,
+                    snippet=snippet or title,
+                    extracted_text=snippet or title,
+                    confidence=0.33,
+                    source_type="search_snippet",
+                    extraction_method="search_snippet_fallback",
+                    fetch_error=page.fetch_error,
+                )
 
             await self._emit_trace(
                 progress_callback,
@@ -167,24 +174,26 @@ class SearchSubagent:
                 },
             )
             source_type, extraction_method = self._source_metadata(page.content_type, page.url)
-            evidence.append(
-                EvidenceRecord(
-                    evidence_id=new_id(),
-                    task_id=task.task_id,
-                    query=task.focus,
-                    requested_url=page.requested_url,
-                    final_url=page.url,
-                    domain=page.domain,
-                    title=page.title,
-                    snippet=extraction.snippet,
-                    extracted_text=extraction.extracted_text,
-                    confidence=extraction.confidence,
-                    fetched_at=page.fetched_at,
-                    published_at=page.published_at,
-                    source_type=source_type,
-                    extraction_method=extraction_method,
-                )
+            return EvidenceRecord(
+                evidence_id=new_id(),
+                task_id=task.task_id,
+                query=task.focus,
+                requested_url=page.requested_url,
+                final_url=page.url,
+                domain=page.domain,
+                title=page.title,
+                snippet=extraction.snippet,
+                extracted_text=extraction.extracted_text,
+                confidence=extraction.confidence,
+                fetched_at=page.fetched_at,
+                published_at=page.published_at,
+                source_type=source_type,
+                extraction_method=extraction_method,
             )
+
+        evidence: list[EvidenceRecord] = await asyncio.gather(
+            *(process_page(page) for page in pages)
+        )
 
         for url in urls:
             canonical_url = canonical_urls.get(url, url)

--- a/shandu/cli.py
+++ b/shandu/cli.py
@@ -199,7 +199,10 @@ def run_command(
         console.print(ui.event_line(event))
 
     console.print(f"[brand]Running:[/] [accent]{request.query}[/]")
-    result = engine.run_sync(request, progress_callback=on_event)
+    try:
+        result = engine.run_sync(request, progress_callback=on_event)
+    finally:
+        engine.close()
 
     if verbose:
         console.print(ui.dashboard(snapshot))
@@ -236,12 +239,15 @@ def ai_search_command(
     json_output: bool,
 ) -> None:
     engine = ShanduEngine.from_config()
-    result = engine.ai_search_sync(
-        query=query,
-        max_results=max_results,
-        max_pages=max_pages,
-        detail_level=_resolve_detail_level(detail_level, "standard"),
-    )
+    try:
+        result = engine.ai_search_sync(
+            query=query,
+            max_results=max_results,
+            max_pages=max_pages,
+            detail_level=_resolve_detail_level(detail_level, "standard"),
+        )
+    finally:
+        engine.close()
 
     if output:
         path = Path(output)

--- a/shandu/engine.py
+++ b/shandu/engine.py
@@ -26,10 +26,12 @@ class ShanduEngine:
         runtime: RuntimeInspectLike,
         orchestrator: OrchestratorLike,
         ai_search_service: AISearchServiceLike,
+        scrape_service: ScrapeService | None = None,
     ) -> None:
         self._runtime = runtime
         self._orchestrator = orchestrator
         self._ai_search = ai_search_service
+        self._scrape_service = scrape_service
 
     @classmethod
     def from_config(cls) -> "ShanduEngine":
@@ -55,6 +57,7 @@ class ShanduEngine:
             runtime=runtime,
             orchestrator=orchestrator,
             ai_search_service=ai_search_service,
+            scrape_service=scrape_service,
         )
 
     async def run(
@@ -134,3 +137,12 @@ class ShanduEngine:
                 detail_level=detail_level,
             )
         )
+
+    async def aclose(self) -> None:
+        if self._scrape_service is not None:
+            await self._scrape_service.aclose()
+
+    def close(self) -> None:
+        if self._scrape_service is None:
+            return
+        get_async_runner().run(self.aclose())

--- a/shandu/services/scrape/extraction.py
+++ b/shandu/services/scrape/extraction.py
@@ -386,15 +386,11 @@ def _detect_fetch_error(html: str | None, status: int | None, text: str) -> str 
             return "empty_js_shell"
 
         weak_text = len(text.split()) < 80
-        html_lower = html.lower()
-
-        captcha_matched = weak_text and any(p.search(html_lower) for p in _CAPTCHA_PATTERNS)
-        if captcha_matched:
-            return "captcha"
-
         if weak_text:
-            paywall_matched = any(p.search(html_lower) for p in _PAYWALL_PATTERNS)
-            if paywall_matched:
+            html_lower = html.lower()
+            if any(p.search(html_lower) for p in _CAPTCHA_PATTERNS):
+                return "captcha"
+            if any(p.search(html_lower) for p in _PAYWALL_PATTERNS):
                 return "paywall"
 
     return None

--- a/shandu/services/scrape/service.py
+++ b/shandu/services/scrape/service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
+from collections import OrderedDict
 from urllib.parse import urlparse, urlsplit, urlunsplit
 
 import aiohttp
@@ -30,6 +31,8 @@ from .models import ScrapedPage, _FetchResult, _ParseError
 from .scheduler import _DomainScheduler
 
 logger = logging.getLogger(__name__)
+
+_PAGE_CACHE_MAX = 128
 
 
 async def _read_limited_response(response: aiohttp.ClientResponse) -> bytes | None:
@@ -104,8 +107,10 @@ class ScrapeService:
         self._timeout_count = 0
         self._total_scrapes = 0
         self._retry_count = 0
-        self._page_cache: dict[str, ScrapedPage] = {}
+        self._page_cache: OrderedDict[str, ScrapedPage] = OrderedDict()
         self._inflight: dict[str, asyncio.Task[ScrapedPage]] = {}
+        self._session: aiohttp.ClientSession | None = None
+        self._session_loop: asyncio.AbstractEventLoop | None = None
         self._headers = dict(_HEADERS)
         self._headers["User-Agent"] = _USER_AGENTS[0]
 
@@ -118,13 +123,9 @@ class ScrapeService:
                 continue
             seen.add(url)
             normalized.append(url)
-        session = await self._get_session()
-        try:
-            tasks = [self.scrape(url, session=session) for url in normalized]
-            results = await asyncio.gather(*tasks, return_exceptions=True)
-        finally:
-            if not session.closed:
-                await session.close()
+        session = await self._shared_session()
+        tasks = [self.scrape(url, session=session) for url in normalized]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
         pages: list[ScrapedPage] = []
         for url, result in zip(normalized, results):
             if isinstance(result, ScrapedPage):
@@ -161,6 +162,7 @@ class ScrapeService:
 
         cached = self._page_cache.get(normalized_url)
         if cached is not None:
+            self._page_cache.move_to_end(normalized_url)
             return cached
 
         in_flight = self._inflight.get(normalized_url)
@@ -190,11 +192,17 @@ class ScrapeService:
                 await active_session.close()
 
         if page.fetch_error is None:
-            self._page_cache[url] = page
+            self._store_page(url, page)
             final_key = _canonicalize_url(page.url)
             if final_key != url:
-                self._page_cache[final_key] = page.model_copy(update={"requested_url": final_key})
+                self._store_page(final_key, page.model_copy(update={"requested_url": final_key}))
         return page
+
+    def _store_page(self, key: str, page: ScrapedPage) -> None:
+        self._page_cache[key] = page
+        self._page_cache.move_to_end(key)
+        while len(self._page_cache) > _PAGE_CACHE_MAX:
+            self._page_cache.popitem(last=False)
 
     async def _scrape_with_retry(
         self,
@@ -203,7 +211,12 @@ class ScrapeService:
         attempt: int,
     ) -> ScrapedPage:
         result = await self._fetch_one(url, session, attempt)
-        if result.retryable and attempt < self._max_attempts - 1:
+        max_attempts = (
+            min(2, self._max_attempts)
+            if result.fetch_error == "timeout"
+            else self._max_attempts
+        )
+        if result.retryable and attempt < max_attempts - 1:
             self._retry_count += 1
             delay = self._backoff_delay(attempt)
             await asyncio.sleep(delay)
@@ -449,3 +462,19 @@ class ScrapeService:
             limit=max(8, self._max_concurrent * 4), ttl_dns_cache=300
         )
         return aiohttp.ClientSession(timeout=timeout, connector=connector)
+
+    async def _shared_session(self) -> aiohttp.ClientSession:
+        loop = asyncio.get_running_loop()
+        session = self._session
+        if session is not None and not session.closed and self._session_loop is loop:
+            return session
+        self._session = await self._get_session()
+        self._session_loop = loop
+        return self._session
+
+    async def aclose(self) -> None:
+        session = self._session
+        self._session = None
+        self._session_loop = None
+        if session is not None and not session.closed:
+            await session.close()

--- a/shandu/services/search.py
+++ b/shandu/services/search.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import time
+from collections import OrderedDict
 from collections.abc import Mapping
 from types import ModuleType
 from typing import Any, Protocol, cast
@@ -14,6 +15,7 @@ from ..config import config
 # ddgs 9.x text backends. "lite"/"html" were duckduckgo_search names and are
 # rejected by ddgs (it falls back to "auto"), so they only add redundant work.
 _TEXT_BACKENDS: tuple[str, ...] = ("duckduckgo", "auto")
+_SEARCH_CACHE_MAX = 256
 
 
 class SearchHit(BaseModel):
@@ -55,7 +57,7 @@ class SearchService:
         self._ddgs = _resolve_ddgs()
         self._region = str(config.get("search", "region", "wt-wt"))
         self._safesearch = str(config.get("search", "safesearch", "moderate"))
-        self._cache: dict[str, tuple[float, list[SearchHit]]] = {}
+        self._cache: OrderedDict[str, tuple[float, list[SearchHit]]] = OrderedDict()
         self._cache_ttl = 300.0
         self._inflight: dict[str, asyncio.Task[list[SearchHit]]] = {}
 
@@ -69,10 +71,14 @@ class SearchService:
         if time.monotonic() - timestamp > self._cache_ttl:
             del self._cache[key]
             return None
+        self._cache.move_to_end(key)
         return hits
 
     def _set_cached(self, key: str, hits: list[SearchHit]) -> None:
         self._cache[key] = (time.monotonic(), hits)
+        self._cache.move_to_end(key)
+        while len(self._cache) > _SEARCH_CACHE_MAX:
+            self._cache.popitem(last=False)
 
     async def search(self, query: str, max_results: int) -> list[SearchHit]:
         if self._ddgs is None:

--- a/shandu/ui/gradio/layout.py
+++ b/shandu/ui/gradio/layout.py
@@ -336,12 +336,15 @@ def _run_action(
         event_queue.put(event)
 
     def run_worker() -> None:
+        engine = None
         try:
             engine = ShanduEngine.from_config()
             result_box["result"] = engine.run_sync(request, progress_callback=on_event)
         except Exception as exc:
             error_box["error"] = str(exc)
         finally:
+            if engine is not None:
+                engine.close()
             event_queue.put(None)
 
     threading.Thread(target=run_worker, daemon=True).start()

--- a/tests/test_citation_agent_fallback.py
+++ b/tests/test_citation_agent_fallback.py
@@ -60,3 +60,42 @@ def test_citation_agent_falls_back_to_deterministic_entries() -> None:
     assert citations[0].citation_id == 1
     assert citations[1].citation_id == 2
     assert set(citations[0].evidence_ids) == {"e1", "e2"}
+
+
+def test_citation_payload_omits_full_body_and_caps_snippet() -> None:
+    class CapturingDesk:
+        def __init__(self) -> None:
+            self.captured: str | None = None
+
+        async def arun(self, worker, job):
+            del worker
+            self.captured = job.input
+            raise RuntimeError("stop")
+
+    class Runtime:
+        def __init__(self, desk: CapturingDesk) -> None:
+            self.settings = SimpleNamespace(model="deepseek/deepseek-v4-flash")
+            self.desk = desk
+
+    desk = CapturingDesk()
+    agent = CitationAgent(runtime=Runtime(desk))
+    evidence = [
+        EvidenceRecord(
+            evidence_id="e1",
+            task_id="t1",
+            query="q",
+            requested_url="https://example.com/a",
+            title="A",
+            snippet="S" * 400,
+            extracted_text="SECRET_BODY_TEXT",
+            confidence=0.8,
+        )
+    ]
+
+    asyncio.run(agent.build_citations("query", evidence))
+
+    assert desk.captured is not None
+    assert "SECRET_BODY_TEXT" not in desk.captured
+    assert "extracted_text" not in desk.captured
+    assert "S" * 280 in desk.captured
+    assert "S" * 281 not in desk.captured

--- a/tests/test_scrape_service.py
+++ b/tests/test_scrape_service.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from shandu.services.scrape import ScrapeService
+import asyncio
+
+from shandu.services.scrape import ScrapeService, ScrapedPage
 
 
 def test_scrape_service_canonicalizes_urls() -> None:
@@ -41,3 +43,80 @@ def test_safe_decode_falls_back_on_unknown_charset() -> None:
     assert _safe_decode(data, "utf-8") == "<html><body>ok</body></html>"
     assert _safe_decode(data, "utf8mb4") == "<html><body>ok</body></html>"
     assert _safe_decode(data, None) == "<html><body>ok</body></html>"
+
+
+def test_scrape_many_reuses_one_session() -> None:
+    service = ScrapeService()
+    created: list[object] = []
+    used: list[object] = []
+
+    class FakeSession:
+        closed = False
+
+        async def close(self) -> None:
+            self.closed = True
+
+    async def fake_get_session() -> object:
+        session = FakeSession()
+        created.append(session)
+        return session
+
+    async def fake_scrape(url: str, session: object = None) -> ScrapedPage:
+        used.append(session)
+        return ScrapedPage(requested_url=url, url=url, title=url, text="t", domain="d")
+
+    service._get_session = fake_get_session  # type: ignore[assignment]
+    service.scrape = fake_scrape  # type: ignore[assignment]
+
+    async def run() -> None:
+        await service.scrape_many(["https://example.com/1"])
+        await service.scrape_many(["https://example.com/2"])
+
+    asyncio.run(run())
+    assert len(created) == 1
+    assert used[0] is used[1]
+
+
+def test_scrape_does_not_close_caller_session() -> None:
+    service = ScrapeService()
+
+    class FakeSession:
+        closed = False
+
+        async def close(self) -> None:
+            self.closed = True
+
+        def get(self, *args, **kwargs):
+            class FakeResponse:
+                url = "https://example.com/"
+                headers = {"content-type": "text/html"}
+                status = 200
+
+                async def __aenter__(self):
+                    return self
+
+                async def __aexit__(self, *args):
+                    pass
+
+                async def text(self, errors=None):
+                    return "<html><body><p>enough words here to pass the content filter easily</p></body></html>"
+
+            return FakeResponse()
+
+    session = FakeSession()
+    asyncio.run(service.scrape("https://example.com", session=session))
+    assert session.closed is False
+
+
+def test_page_cache_evicts_oldest() -> None:
+    from shandu.services.scrape.service import _PAGE_CACHE_MAX
+
+    service = ScrapeService()
+    for i in range(_PAGE_CACHE_MAX + 10):
+        service._store_page(
+            f"k{i}",
+            ScrapedPage(requested_url=f"k{i}", url=f"k{i}", title="t", text="x", domain="d"),
+        )
+    assert len(service._page_cache) == _PAGE_CACHE_MAX
+    assert "k0" not in service._page_cache
+    assert f"k{_PAGE_CACHE_MAX + 9}" in service._page_cache

--- a/tests/test_scrape_timeout_logging.py
+++ b/tests/test_scrape_timeout_logging.py
@@ -25,10 +25,47 @@ def test_scrape_timeout_increments_counter():
     result = asyncio.run(service.scrape("https://example.com", session=fake_session))
     assert result is not None
     assert result.fetch_error == "timeout"
-    # Initial attempt + 2 retries = 3 timeouts
-    assert service._timeout_count == 3
-    assert service._retry_count == 2
+    # Timeouts get at most one retry: initial attempt + 1 retry = 2 timeouts.
+    assert service._timeout_count == 2
+    assert service._retry_count == 1
     assert service._total_scrapes == 1
+
+
+def test_retryable_status_uses_full_attempt_budget():
+    service = ScrapeService()
+    service._backoff_delay = lambda attempt: 0.0
+    call_count = 0
+
+    class FakeSession:
+        closed = False
+
+        async def close(self):
+            pass
+
+        def get(self, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+
+            class FakeResponse:
+                url = "https://example.com"
+                headers = {"content-type": "text/html"}
+                status = 429
+
+                async def __aenter__(self):
+                    return self
+
+                async def __aexit__(self, *args):
+                    pass
+
+            return FakeResponse()
+
+    fake_session = FakeSession()
+    result = asyncio.run(service.scrape("https://example.com", session=fake_session))
+    assert result is not None
+    assert result.http_status == 429
+    # 429 is retryable but not a timeout, so it uses the full attempt budget.
+    assert call_count == service._max_attempts
+    assert service._retry_count == service._max_attempts - 1
 
 
 def test_scrape_success_after_retry():

--- a/tests/test_search_backend.py
+++ b/tests/test_search_backend.py
@@ -14,3 +14,14 @@ def test_search_backends_exclude_stale_names() -> None:
     assert "lite" not in _TEXT_BACKENDS
     assert "html" not in _TEXT_BACKENDS
     assert "duckduckgo" in _TEXT_BACKENDS
+
+
+def test_search_cache_evicts_oldest() -> None:
+    from shandu.services.search import _SEARCH_CACHE_MAX
+
+    service = SearchService()
+    for i in range(_SEARCH_CACHE_MAX + 5):
+        service._set_cached(f"k{i}", [])
+    assert len(service._cache) == _SEARCH_CACHE_MAX
+    assert "k0" not in service._cache
+    assert f"k{_SEARCH_CACHE_MAX + 4}" in service._cache

--- a/tests/test_search_subagent_fallback.py
+++ b/tests/test_search_subagent_fallback.py
@@ -182,3 +182,99 @@ def test_search_subagent_emits_search_and_scrape_traces() -> None:
     assert "scrape_started" in traces
     assert "scrape_completed" in traces
     assert "fallback_evidence" in traces
+
+
+def test_extraction_preserves_page_order_under_concurrency() -> None:
+    from shandu.agents.search_subagent import _ExtractionPayload
+
+    class ThreeHitSearch:
+        async def search(self, query: str, max_results: int):
+            del query, max_results
+            return [
+                SearchHit(query="q", url=f"https://example.com/{i}", title=f"H{i}", snippet=f"s{i}")
+                for i in range(3)
+            ]
+
+    class ThreePageScrape:
+        async def scrape_many(self, urls: list[str]):
+            del urls
+            return [
+                ScrapedPage(
+                    requested_url=f"https://example.com/{i}",
+                    url=f"https://example.com/{i}",
+                    title=f"T{i}",
+                    text=f"text {i}",
+                    domain="example.com",
+                )
+                for i in range(3)
+            ], 0
+
+    class OutOfOrderDesk:
+        def __init__(self) -> None:
+            self._n = 0
+
+        async def arun(self, worker, job):
+            del worker, job
+            idx = self._n
+            self._n += 1
+            await asyncio.sleep(0.03 * (3 - idx))
+            return SimpleNamespace(
+                status="completed",
+                data=_ExtractionPayload(snippet="s", extracted_text="body", confidence=0.7),
+            )
+
+    class Runtime:
+        def __init__(self, desk: OutOfOrderDesk) -> None:
+            self.settings = SimpleNamespace(model="deepseek/deepseek-v4-flash")
+            self.desk = desk
+
+    subagent = SearchSubagent(
+        runtime=Runtime(OutOfOrderDesk()),
+        search_service=ThreeHitSearch(),
+        scrape_service=ThreePageScrape(),
+    )
+    task = SubagentTask(task_id="task-1", focus="focus", search_queries=["q"], expected_output="out")
+    request = ResearchRequest(query="q", max_pages_per_task=3, max_results_per_query=3)
+
+    evidence = asyncio.run(subagent.execute_task("run:1", task, request))
+
+    assert [item.requested_url for item in evidence] == [
+        "https://example.com/0",
+        "https://example.com/1",
+        "https://example.com/2",
+    ]
+    assert all(item.extracted_text == "body" for item in evidence)
+
+
+def test_query_merge_preserves_query_order_under_concurrency() -> None:
+    class PerQuerySearch:
+        async def search(self, query: str, max_results: int):
+            del max_results
+            if query == "q1":
+                await asyncio.sleep(0.04)
+            mapping = {
+                "q1": [("https://example.com/a", "A"), ("https://example.com/b", "B")],
+                "q2": [("https://example.com/b", "B2"), ("https://example.com/c", "C")],
+            }
+            return [
+                SearchHit(query=query, url=url, title=title, snippet="s")
+                for url, title in mapping.get(query, [])
+            ]
+
+    subagent = SearchSubagent(
+        runtime=FakeRuntime(),
+        search_service=PerQuerySearch(),
+        scrape_service=EmptyScrapeService(),
+    )
+    task = SubagentTask(
+        task_id="task-1", focus="focus", search_queries=["q1", "q2"], expected_output="out"
+    )
+    request = ResearchRequest(query="q", max_pages_per_task=5, max_results_per_query=5)
+
+    evidence = asyncio.run(subagent.execute_task("run:1", task, request))
+
+    assert [item.requested_url for item in evidence] == [
+        "https://example.com/a",
+        "https://example.com/b",
+        "https://example.com/c",
+    ]


### PR DESCRIPTION
Same research results, less wall-clock and less waste. No new dependencies, no behavior redesign.

## Faster

- **Per-page extraction runs concurrently.** Pages were scraped in parallel, but each page's extractor LLM call ran one after another, serializing several seconds of latency per page. Each page's record now resolves via `asyncio.gather`; evidence stays in page order and fetch-error fallbacks keep their position. (`agents/search_subagent.py`)
- **Search queries within a task run concurrently.** A task carries 2-4 queries, each a network call on a 12s timeout. They now run together and merge query-by-query in original order, so dedup priority and the `max_pages_per_task` cut stay deterministic. (`agents/search_subagent.py`)
- **One HTTP session per ScrapeService.** `scrape_many` built and closed a fresh `ClientSession`/`TCPConnector` on every call, so connection and DNS reuse across a run never happened and `ttl_dns_cache` was dead. The service now holds one lazily-created session bound to the running loop and reuses it; `ShanduEngine.close()` releases it, wired into the CLI and GUI run paths. A caller-provided session is never closed by the service. (`services/scrape/service.py`, `engine.py`, `cli.py`, `ui/gradio/layout.py`)

## Less waste

- **Citation agent gets a projection, not full bodies.** `build_citations` serialized entire `EvidenceRecord` objects, including `extracted_text`, into the prompt. It now sends `{evidence_id, requested_url, final_url, title, domain, snippet}` with `snippet` capped at 280 chars. The citation schema and fallback read the live records, so output is unchanged. (`agents/citation_agent.py`)
- **Dead URLs cost less.** A timed-out fetch got the full 3 attempts with `2^attempt` backoff (~63s for one hung URL, and `scrape_many` waits on its slowest member). Timeouts now get at most one retry; retryable HTTP statuses (429/5xx/408) keep the full budget. (`services/scrape/service.py`)
- **Caches are bounded.** The page cache (128) and search cache (256) are now LRU `OrderedDict`s instead of unbounded dicts; search TTL is preserved. This is a defensive within-run bound, not a cross-run leak (the GUI rebuilds the engine per run). (`services/scrape/service.py`, `services/search.py`)
- **No lowercase copy per HTML fetch unless needed.** `_detect_fetch_error` built `html.lower()` on every HTML fetch though it is only used in weak-text-gated checks; now computed only when reached. (`services/scrape/extraction.py`)

## Tests

Eight new tests over the existing fakes: extraction order under out-of-order completion, query-merge order and dedup, citation payload omits bodies and caps snippets, a timeout attempted exactly twice vs a 429 using the full budget, session reuse across two `scrape_many` calls, caller-session not closed, and page/search cache eviction. The `test_scrape_timeout_logging.py` timeout assertions move from 3 to 2 to match the new retry policy.

## Verification

- `ruff check shandu/ tests/` clean
- `pytest -q`: 95 passed
