### PR TITLE
Fix runtime teardown racing in-flight runs on GUI config save

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shandu"
-version = "3.1.0"
+version = "3.1.1"
 description = "Open-source deep research agent: multi-agent web search, scraping, source-credibility scoring, and citation-backed reports with any LiteLLM model"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/shandu/__init__.py
+++ b/shandu/__init__.py
@@ -1,6 +1,6 @@
 from .contracts import AISearchResult, ResearchRequest, ResearchRunResult, RunEvent
 from .engine import ShanduEngine
 
-__version__ = "3.1.0"
+__version__ = "3.1.1"
 
 __all__ = ["AISearchResult", "ResearchRequest", "ResearchRunResult", "RunEvent", "ShanduEngine"]

--- a/shandu/ui/gradio/settings.py
+++ b/shandu/ui/gradio/settings.py
@@ -10,6 +10,23 @@ from ...runtime import reset_bootstrap
 from .constants import DEPTH_POLICIES, DETAIL_LEVELS
 
 
+# Only these config values feed RuntimeBootstrap. Orchestration values are
+# read per-request, so saving them must not tear down the shared runtime:
+# reset_bootstrap() closes SQLite stores that any in-flight run still holds,
+# and the GUI saves configuration at the start of every run.
+_RUNTIME_KEYS: tuple[tuple[str, str], ...] = (
+    ("api", "model"),
+    ("api", "api_key_env"),
+    ("api", "api_key"),
+    ("api", "temperature"),
+    ("api", "max_tokens"),
+)
+
+
+def _runtime_snapshot() -> tuple[str, ...]:
+    return tuple(str(config.get(section, key, "")) for section, key in _RUNTIME_KEYS)
+
+
 @dataclass(frozen=True, slots=True)
 class GuiDefaults:
     model: str
@@ -74,6 +91,7 @@ def save_configuration(
     key_text = str(api_key_value or "").strip()
 
     resolved_env = env_text or infer_api_key_env_name(model_text)
+    runtime_before = _runtime_snapshot()
     config.set("api", "model", model_text)
     config.set("api", "api_key_env", resolved_env)
     if key_text:
@@ -107,7 +125,8 @@ def save_configuration(
         int(max_pages_per_task) if max_pages_per_task is not None else 3,
     )
     config.save()
-    reset_bootstrap()
+    if _runtime_snapshot() != runtime_before:
+        reset_bootstrap()
     config.apply_provider_api_key()
     return f"Saved configuration for `{model_text}` using env key `{resolved_env}`."
 

--- a/tests/test_gui_settings.py
+++ b/tests/test_gui_settings.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from shandu.ui.gradio import settings
+
+
+def _isolate_config(monkeypatch) -> dict[tuple[str, str], object]:
+    store: dict[tuple[str, str], object] = {}
+    monkeypatch.setattr(
+        settings.config, "get", lambda section, key, default=None: store.get((section, key), default)
+    )
+    monkeypatch.setattr(
+        settings.config, "set", lambda section, key, value: store.__setitem__((section, key), value)
+    )
+    monkeypatch.setattr(settings.config, "save", lambda: None)
+    monkeypatch.setattr(settings.config, "apply_provider_api_key", lambda: None)
+    return store
+
+
+_ARGS = {
+    "model": "deepseek/deepseek-v4-flash",
+    "api_key_env": "DEEPSEEK_API_KEY",
+    "api_key_value": "",
+    "temperature": 0.2,
+    "max_tokens": 16384,
+    "max_iterations": 2,
+    "parallelism": 3,
+    "detail_level": "high",
+    "depth_policy": "adaptive",
+    "max_results_per_query": 5,
+    "max_pages_per_task": 3,
+}
+
+
+def test_save_configuration_resets_runtime_only_when_runtime_values_change(
+    monkeypatch,
+) -> None:
+    _isolate_config(monkeypatch)
+    resets: list[int] = []
+    monkeypatch.setattr(settings, "reset_bootstrap", lambda: resets.append(1))
+
+    settings.save_configuration(**_ARGS)
+    assert len(resets) == 1
+
+    settings.save_configuration(**_ARGS)
+    assert len(resets) == 1
+
+    settings.save_configuration(**{**_ARGS, "temperature": 0.7})
+    assert len(resets) == 2
+
+
+def test_save_configuration_ignores_orchestration_only_changes(monkeypatch) -> None:
+    _isolate_config(monkeypatch)
+    resets: list[int] = []
+    monkeypatch.setattr(settings, "reset_bootstrap", lambda: resets.append(1))
+
+    settings.save_configuration(**_ARGS)
+    settings.save_configuration(**{**_ARGS, "parallelism": 6, "max_iterations": 4})
+
+    assert len(resets) == 1
+
+
+def test_save_configuration_resets_on_new_api_key(monkeypatch) -> None:
+    _isolate_config(monkeypatch)
+    resets: list[int] = []
+    monkeypatch.setattr(settings, "reset_bootstrap", lambda: resets.append(1))
+
+    settings.save_configuration(**_ARGS)
+    settings.save_configuration(**{**_ARGS, "api_key_value": "sk-new"})
+
+    assert len(resets) == 2

--- a/uv.lock
+++ b/uv.lock
@@ -2587,7 +2587,7 @@ wheels = [
 
 [[package]]
 name = "shandu"
-version = "3.1.0"
+version = "3.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Running from the GUI could fail with "Cannot operate on a closed database" and silently fall back to the deterministic planner. The cause: the GUI saves configuration at the start of every run, and save_configuration always called reset_bootstrap(), which closes the shared runtime's SQLite stores. Any overlapping handler execution (a double-fired start event, a second run, or the save button) closed the stores an in-flight run was still using.

Fix: only the api-section values (model, key env, key, temperature, max tokens) feed the runtime, so save_configuration now snapshots them before writing and rebuilds the runtime only when they actually changed. Re-saving unchanged settings, or changing orchestration-only settings, no longer touches the runtime at all, which removes the every-run-start trigger entirely.

Residual: actively changing the model or API key while a run is in flight still rebuilds the runtime under it. That needs an in-flight guard on the bootstrap and belongs with the UI rework, not a hotfix.

Three new tests pin the behavior (no reset on identical save, no reset on orchestration-only change, reset on model/key change). Full suite: 123 passed, ruff clean. Version bumped to 3.1.1.